### PR TITLE
Make importlab run under Python 2.7.

### DIFF
--- a/importlab/parsepy.py
+++ b/importlab/parsepy.py
@@ -74,6 +74,9 @@ def get_imports(filename, python_version):
   else:
       # Call the appropriate python version in a subprocess
       f = sys.modules['importlab.import_finder'].__file__
+      if f.rsplit('.', 1)[-1] == 'pyc':
+        # In host Python 2, importlab ships with .pyc files.
+        f = f[:-1]
       ret, stdout, stderr = runner.run_py_file(python_version, f, filename)
       if not ret:
           if sys.version_info[0] == 3:

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,11 @@ from setuptools import find_packages, setup, Command
 
 # Package meta-data.
 NAME = 'importlab'
-DESCRIPTION = 'A tool to run static analysis over large python projects.'
+DESCRIPTION = 'A tool to calculate dependency graphs of Python files.'
 URL = 'https://github.com/google/importlab'
 EMAIL = 'pytype-dev@google.com'
 AUTHOR = 'Google Inc.'
-REQUIRES_PYTHON = '>=3.6.0'
+REQUIRES_PYTHON = '>=2.7.0'
 VERSION = '0.1'
 
 REQUIRED = [
@@ -53,7 +53,7 @@ setup(
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
     ],


### PR DESCRIPTION
Pytype can run under 2.7 and 3.6, but pytype-all could only run under
3.6. There's not much point in advertising pytype as running under both
versions if the only useful way to use pytype requires 3.6. Importlab
appears to have already been 2-and-3 compatible except for a single issue
in parsepy, which I fixed.

Tested by installing importlab in
/usr/local/lib/python{2.7,3.6}/dist-packages and verifying that both
installations are able to compute a dependency graph for a random pytype
file (output.py) with both -V2.7 and -V3.6.