### PR TITLE
Some small improvements to error reporting.

### DIFF
--- a/importlab/import_finder.py
+++ b/importlab/import_finder.py
@@ -122,7 +122,7 @@ def get_imports(filename):
     with open(filename, "rb") as f:
         src = f.read()
     finder = ImportFinder()
-    finder.visit(ast.parse(src))
+    finder.visit(ast.parse(src, filename=filename))
     imports = []
     for i in finder.imports:
         name, _, is_from, is_star = i

--- a/importlab/parsepy.py
+++ b/importlab/parsepy.py
@@ -15,6 +15,7 @@
 """Logic for resolving import paths."""
 
 import collections
+import logging
 import sys
 
 from . import import_finder
@@ -82,6 +83,8 @@ def get_imports(filename, python_version):
                 stdout = stdout.decode('ascii')
             imports = import_finder.read_imports(stdout)
         else:
-            print(stderr)
+            if sys.version_info[0] == 3:
+                stderr = stderr.decode('ascii')
+            logging.info(stderr)
             raise Exception('parse error for ' + filename)
     return [ImportStatement(*imp) for imp in imports]

--- a/importlab/resolve.py
+++ b/importlab/resolve.py
@@ -14,6 +14,7 @@
 
 """Logic for resolving import paths."""
 
+import logging
 import os
 
 from . import import_finder
@@ -117,7 +118,7 @@ class Resolver:
             try:
                 yield self.resolve_import(import_item)
             except ImportException as err:
-                print('unknown module', err.module_name)
+                logging.info('unknown module %s', err.module_name)
 
 
 def show_import_tree(self, seen=None, indent=0):

--- a/tests/test_parsepy.py
+++ b/tests/test_parsepy.py
@@ -208,7 +208,7 @@ class TestParsePy(unittest.TestCase):
             b'# -*- coding: iso-8859-1 -*-\n' +
             b'# Copyright (C) 1984 F' + chr(0xf6) + b'man\n'
         )
-        self.assertRaises(UnicodeDecodeError, unicode, src)
+        self.assertRaises(UnicodeDecodeError, unicode, src)  # noqa: F821
         self.assertEqual(self.parse(src), [])
 
 


### PR DESCRIPTION
* Replaced print() statements that were used as logging statements
  with logging. Also decoded a traceback bytestring so that it wouldn't
  show up as one long string.
* Passed a filename to ast.parse() so that the offending file appears
  in SyntaxError messages.

Also silenced a flake8 warning.