### PR TITLE
Track the provenance of all resolved paths in the import graph.

### DIFF
--- a/importlab/graph.py
+++ b/importlab/graph.py
@@ -5,13 +5,13 @@ import networkx as nx
 
 from . import resolve
 from . import parsepy
+from . import utils
 
 
 class Cycle(object):
     """A cycle of nodes, some of which might be cycles."""
 
-    def __init__(self, edges, root=''):
-        self.root = root
+    def __init__(self, edges):
         self.edges = edges
         self.nodes = [x[0] for x in self.edges]
 
@@ -19,7 +19,7 @@ class Cycle(object):
         if isinstance(node, Cycle):
             return node.pp()
         else:
-            return os.path.relpath(node, self.root)
+            return node
 
     def flatten_nodes(self):
         out = []
@@ -44,17 +44,13 @@ class NodeSet(object):
     """The flattened version of a cycle - a set of mutually dependent files."""
 
     def __init__(self, cycle):
-        self.root = cycle.root
         self.nodes = cycle.flatten_nodes()
 
     def __contains__(self, v):
         return v in self.nodes
 
-    def _fmt(self, node):
-        return os.path.relpath(node, self.root)
-
     def pp(self):
-        return '[' + '->'.join([self._fmt(f) for f in self.nodes]) + ']'
+        return '[' + '->'.join([str(f) for f in self.nodes]) + ']'
 
     def __str__(self):
         return self.pp()
@@ -84,8 +80,10 @@ class DependencyGraph(object):
     def __init__(self):
         self.graph = nx.DiGraph()
         self.broken_deps = collections.defaultdict(set)
-        self.root = None
         self.final = False
+        # sources is a set of files directly added to the graph via
+        # add_file or add_file_recursive.
+        self.sources = set()
 
     def get_file_deps(self, filename):
         raise NotImplementedError()
@@ -106,6 +104,7 @@ class DependencyGraph(object):
         """Add a file and all its recursive dependencies to the graph."""
 
         assert not self.final, 'Trying to mutate a final graph.'
+        self.sources.add(filename)
         queue = collections.deque([filename])
         seen = set()
         while queue:
@@ -123,14 +122,6 @@ class DependencyGraph(object):
                 self.graph.add_node(f)
                 self.graph.add_edge(filename, f)
 
-    def find_root(self, recalculate=False):
-        if recalculate or not self.root:
-            keys = set(x[0] for x in self.graph.edges)
-            prefix = os.path.commonprefix(list(keys))
-            if not os.path.isdir(prefix):
-                prefix = os.path.dirname(prefix)
-            self.root = prefix
-        return self.root
 
     def extract_cycle(self, cycle):
         assert not self.final, 'Trying to mutate a final graph.'
@@ -147,10 +138,10 @@ class DependencyGraph(object):
             self.graph.remove_node(node)
 
     def format(self, node):
-        prefix = self.find_root()
         if isinstance(node, (Cycle, NodeSet)):
             return node.pp()
-        return os.path.relpath(node, prefix)
+        else:
+          return node
 
     def inspect_graph(self):
         keys = set(x[0] for x in self.graph.edges)
@@ -168,10 +159,9 @@ class DependencyGraph(object):
         assert not self.final, 'Trying to mutate a final graph.'
 
         # Recursively extract cycles until the graph is cycle-free.
-        prefix = self.find_root()
         while True:
             try:
-                cycle = Cycle(nx.find_cycle(self.graph), prefix)
+                cycle = Cycle(nx.find_cycle(self.graph))
                 self.extract_cycle(cycle)
             except nx.NetworkXNoCycle:
                 break

--- a/importlab/graph.py
+++ b/importlab/graph.py
@@ -84,7 +84,7 @@ class DependencyGraph(object):
         # add_file or add_file_recursive.
         self.sources = set()
         # provenance is a map of file path (as stored in the graph) to where the
-        # file was sourced from (see resolve.ResolvedImport)
+        # file was sourced from (see resolve.ResolvedFile)
         self.provenance = {}
 
     def get_file_deps(self, filename):

--- a/importlab/graph.py
+++ b/importlab/graph.py
@@ -5,7 +5,6 @@ import networkx as nx
 
 from . import resolve
 from . import parsepy
-from . import utils
 
 
 class Cycle(object):
@@ -84,33 +83,42 @@ class DependencyGraph(object):
         # sources is a set of files directly added to the graph via
         # add_file or add_file_recursive.
         self.sources = set()
+        # provenance is a map of file path (as stored in the graph) to where the
+        # file was sourced from (see resolve.ResolvedImport)
+        self.provenance = {}
 
     def get_file_deps(self, filename):
         raise NotImplementedError()
+
+    def _add_source_file(self, filename):
+        self.sources.add(filename)
+        self.provenance[filename] = resolve.Direct(filename)
 
     def add_file(self, filename):
         """Add a file and all its immediate dependencies to the graph."""
 
         assert not self.final, 'Trying to mutate a final graph.'
-        resolved, unresolved = self.get_file_deps(filename)
+        self._add_source_file(filename)
+        resolved, unresolved, provenance = self.get_file_deps(filename)
         self.graph.add_node(filename)
         for f in resolved:
             self.graph.add_node(f)
             self.graph.add_edge(filename, f)
         for imp in unresolved:
             self.broken_deps[filename].add(imp)
+        self.provenance.update(provenance)
 
     def add_file_recursive(self, filename):
         """Add a file and all its recursive dependencies to the graph."""
 
         assert not self.final, 'Trying to mutate a final graph.'
-        self.sources.add(filename)
+        self._add_source_file(filename)
         queue = collections.deque([filename])
         seen = set()
         while queue:
             filename = queue.popleft()
             self.graph.add_node(filename)
-            deps, broken = self.get_file_deps(filename)
+            deps, broken, provenance = self.get_file_deps(filename)
             for f in broken:
                 self.broken_deps[filename].add(f)
             for f in deps:
@@ -121,7 +129,7 @@ class DependencyGraph(object):
                     seen.add(f)
                 self.graph.add_node(f)
                 self.graph.add_edge(filename, f)
-
+            self.provenance.update(provenance)
 
     def extract_cycle(self, cycle):
         assert not self.final, 'Trying to mutate a final graph.'
@@ -141,7 +149,7 @@ class DependencyGraph(object):
         if isinstance(node, (Cycle, NodeSet)):
             return node.pp()
         else:
-          return node
+            return node
 
     def inspect_graph(self):
         keys = set(x[0] for x in self.graph.edges)
@@ -244,11 +252,14 @@ class ImportGraph(DependencyGraph):
         r = resolve.Resolver(self.path, filename)
         resolved = []
         unresolved = []
+        provenance = {}
         for imp in parsepy.get_imports(filename, self.env.python_version):
             try:
                 f = r.resolve_import(imp)
-                if not f.endswith('.so'):
-                    resolved.append(os.path.abspath(f))
+                if not f.is_extension():
+                    full_path = os.path.abspath(f.path)
+                    resolved.append(full_path)
+                    provenance[full_path] = f
             except resolve.ImportException:
                 unresolved.append(imp)
-        return (resolved, unresolved)
+        return (resolved, unresolved, provenance)

--- a/importlab/output.py
+++ b/importlab/output.py
@@ -27,11 +27,11 @@ def format_file_node(import_graph, node, indent):
         out = os.path.relpath(f.path, f.fs.path)
     elif isinstance(f, resolve.Relative):
         # TODO(martindemello): Format depending on provenance[f.from_path]
-        out = '. ' + os.path.relpath(f.path, os.path.dirname(f.from_path))
+        out = '. ' + f.short_path
     elif isinstance(f, resolve.System):
-        out = ':: ' + f.import_item.name
+        out = ':: ' + f.short_path
     elif isinstance(f, resolve.Builtin):
-        out = '(%s)' % f.path
+        out = '(%s)' % f.module_name
     else:
         out = '%r' % node
     return '  '*indent + out

--- a/importlab/output.py
+++ b/importlab/output.py
@@ -22,12 +22,12 @@ def format_file_node(import_graph, node, indent):
     """Prettyprint nodes based on their provenance."""
     f = import_graph.provenance[node]
     if isinstance(f, resolve.Direct):
-      out = f.path
+        out = f.path
     elif isinstance(f, resolve.Local):
-      out = os.path.relpath(f.path, f.fs.path)
+        out = os.path.relpath(f.path, f.fs.path)
     elif isinstance(f, resolve.Relative):
-      # TODO(martindemello): Format depending on provenance[f.from_path]
-      out = '. ' + os.path.relpath(f.path, os.path.dirname(f.from_path))
+        # TODO(martindemello): Format depending on provenance[f.from_path]
+        out = '. ' + os.path.relpath(f.path, os.path.dirname(f.from_path))
     elif isinstance(f, resolve.System):
         out = ':: ' + f.import_item.name
     elif isinstance(f, resolve.Builtin):

--- a/importlab/parsepy.py
+++ b/importlab/parsepy.py
@@ -39,6 +39,7 @@ class ImportStatement(collections.namedtuple(
           be an element within a module, instead of a module itself. Happens
           e.g. for "from sys import argv".
           is_star: If this is an import of the form "from x import *".
+          source: The path to the file as resolved by python.
         Returns:
           A new ImportStatement instance.
         """

--- a/importlab/parsepy.py
+++ b/importlab/parsepy.py
@@ -24,10 +24,10 @@ from . import runner
 
 class ImportStatement(collections.namedtuple(
         'ImportStatement',
-        ['name', 'new_name', 'is_from', 'everything', 'source'])):
+        ['name', 'new_name', 'is_from', 'is_star', 'source'])):
     """A Python import statement, such as "import foo as bar"."""
 
-    def __new__(cls, name, new_name=None, is_from=False, everything=False,
+    def __new__(cls, name, new_name=None, is_from=False, is_star=False,
                 source=None):
         """Create a new ImportStatement.
 
@@ -38,18 +38,18 @@ class ImportStatement(collections.namedtuple(
           is_from: If the last part of the name (the "z" in "x.y.z") can
           be an element within a module, instead of a module itself. Happens
           e.g. for "from sys import argv".
-          everything: If this is an import of the form "from x import *".
+          is_star: If this is an import of the form "from x import *".
         Returns:
           A new ImportStatement instance.
         """
         return super(ImportStatement, cls).__new__(
-            cls, name, new_name or name, is_from, everything, source)
+            cls, name, new_name or name, is_from, is_star, source)
 
     def is_relative(self):
         return self.name.startswith('.')
 
     def __str__(self):
-        if self.everything:
+        if self.is_star:
             assert self.name == self.new_name
             assert self.is_from
             return 'from ' + self.name + ' import *'

--- a/importlab/resolve.py
+++ b/importlab/resolve.py
@@ -18,6 +18,7 @@ import logging
 import os
 
 from . import import_finder
+from . import utils
 
 
 class ImportException(ImportError):
@@ -164,6 +165,7 @@ class Resolver:
             # We need to check for importing a symbol here too.
             if short_name:
                 mod = prefix.replace(os.path.sep, '.')
+                mod = utils.strip_suffix(mod, '.__init__')
                 if not mod.endswith(name) and mod.endswith(short_name):
                     mod_name = short_name
 

--- a/importlab/resolve.py
+++ b/importlab/resolve.py
@@ -142,7 +142,7 @@ class Resolver:
         # The last part in `from a.b.c import d` might be a symbol rather than a
         # module, so we try both a/b/c/d.py and a/b/c.py
         files = [(name, filename)]
-        if item.is_from:
+        if item.is_from and not item.is_star:
             short_filename = os.path.dirname(filename)
             short_name = name[:name.rfind('.')]
             files.append((short_name, short_filename))
@@ -161,7 +161,7 @@ class Resolver:
         if item.source:
             prefix, ext = os.path.splitext(item.source)
             # We need to check for importing a symbol here too.
-            if item.is_from:
+            if item.is_from and not item.is_star:
                 components = item.name.split('.')
                 if (not prefix.endswith(components[-1]) and
                     prefix.endswith(components[-2])):

--- a/importlab/resolve.py
+++ b/importlab/resolve.py
@@ -160,6 +160,13 @@ class Resolver:
         # itself resolved it.
         if item.source:
             prefix, ext = os.path.splitext(item.source)
+            # We need to check for importing a symbol here too.
+            if item.is_from:
+                components = item.name.split('.')
+                if (not prefix.endswith(components[-1]) and
+                    prefix.endswith(components[-2])):
+                    name = '.'.join(components[:-1])
+
             if ext == '.pyc':
                 pyfile = prefix + '.py'
                 if os.path.exists(pyfile):

--- a/importlab/resolve.py
+++ b/importlab/resolve.py
@@ -41,7 +41,6 @@ class Direct(ResolvedFile):
 
 class Builtin(ResolvedFile):
     """Imports that are resolved via python's builtins."""
-
     def is_extension(self):
         return True
 

--- a/importlab/resolve.py
+++ b/importlab/resolve.py
@@ -105,7 +105,7 @@ class Resolver:
         py = name + '.py'
         for x in [init, py]:
             if fs.isfile(x):
-                return x
+                return fs.refer_to(x)
         return None
 
     def resolve_import(self, item):

--- a/importlab/utils.py
+++ b/importlab/utils.py
@@ -59,14 +59,6 @@ def makedirs(path):
             raise
 
 
-def get_parent_directory(filenames):
-    """Get the common parent directory of a file tree."""
-    prefix = os.path.commonprefix(filenames)
-    if not os.path.isdir(prefix):
-        prefix = os.path.dirname(prefix)
-    return prefix
-
-
 class Tempdir(object):
     """Context handler for creating temporary directories."""
 
@@ -118,3 +110,10 @@ class Tempdir(object):
     def __getitem__(self, filename):
         """Get the full path for an entry in this directory."""
         return os.path.join(self.path, filename)
+
+
+def strip_suffix(string, suffix):
+    """Remove a suffix from a string if it exists."""
+    if string.endswith(suffix):
+        return string[:-(len(suffix))]
+    return string

--- a/importlab/utils.py
+++ b/importlab/utils.py
@@ -59,6 +59,14 @@ def makedirs(path):
             raise
 
 
+def get_parent_directory(filenames):
+    """Get the common parent directory of a file tree."""
+    prefix = os.path.commonprefix(filenames)
+    if not os.path.isdir(prefix):
+        prefix = os.path.dirname(prefix)
+    return prefix
+
+
 class Tempdir(object):
     """Context handler for creating temporary directories."""
 

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -121,6 +121,10 @@ class TestPYIFileSystem(unittest.TestCase):
         self.assertFalse(self.fs.isdir("foo/c.py"))
         self.assertFalse(self.fs.isdir("a.py"))
 
+    def testFullPath(self):
+        self.assertEqual(self.fs.refer_to("foo/c.py"),
+                         self.tempdir["foo/c.pyi"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -3,6 +3,7 @@
 import unittest
 
 from importlab import graph
+from importlab import resolve
 
 
 class TestCycle(unittest.TestCase):
@@ -29,7 +30,7 @@ class FakeImportGraph(graph.DependencyGraph):
     def get_file_deps(self, filename):
         if filename in self.deps:
             return self.deps[filename]
-        return ([], [])
+        return ([], [], {})
 
     def ordered_deps_list(self):
         deps = []
@@ -41,17 +42,21 @@ class FakeImportGraph(graph.DependencyGraph):
         return [list(sorted(x)) for x in self.sorted_source_files()]
 
 
-# Deps = { file : ([resolved deps], [broken deps]) }
+# Deps = { file : ([resolved deps], [broken deps], {dep_file:provenance}) }
 
 SIMPLE_DEPS = {
-        "a.py": (["b.py", "c.py"], []),
-        "b.py": (["d.py"], ["e"])
-        }
+        "a.py": (["b.py", "c.py"], [],
+                 {"b.py": resolve.Local("b.py", "fs1"),
+                  "c.py": resolve.Local("c.py", "fs2")
+                  }),
+        "b.py": (["d.py"], ["e"],
+                 {"d.py": resolve.System("d.py", "d.py")})
+}
 
 SIMPLE_CYCLIC_DEPS = {
-        "a.py": (["b.py", "c.py"], ["e"]),
-        "b.py": (["d.py", "a.py"], ["f"]),
-        }
+        "a.py": (["b.py", "c.py"], ["e"], {}),
+        "b.py": (["d.py", "a.py"], ["f"], {}),
+}
 
 
 class TestImportGraph(unittest.TestCase):
@@ -77,6 +82,12 @@ class TestImportGraph(unittest.TestCase):
         sources = g.ordered_sorted_source_files()
         self.check_order(sources, ["d.py"], ["b.py"], ["a.py"])
         self.check_order(sources, ["c.py"], ["a.py"])
+        self.assertEqual(sorted(g.provenance.keys()),
+                         ["a.py", "b.py", "c.py", "d.py"])
+        # a.py is a directly added source
+        self.assertTrue(isinstance(g.provenance["a.py"], resolve.Direct))
+        # b.py came from fs1
+        self.assertEqual(g.provenance["b.py"].fs, "fs1")
 
     def test_simple_cycle(self):
         g = FakeImportGraph(SIMPLE_CYCLIC_DEPS)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -46,11 +46,11 @@ class FakeImportGraph(graph.DependencyGraph):
 
 SIMPLE_DEPS = {
         "a.py": (["b.py", "c.py"], [],
-                 {"b.py": resolve.Local("b.py", "fs1"),
-                  "c.py": resolve.Local("c.py", "fs2")
+                 {"b.py": resolve.Local("b.py", "b", "fs1"),
+                  "c.py": resolve.Local("c.py", "c", "fs2")
                   }),
         "b.py": (["d.py"], ["e"],
-                 {"d.py": resolve.System("d.py", "d.py")})
+                 {"d.py": resolve.System("d.py", "d")})
 }
 
 SIMPLE_CYCLIC_DEPS = {

--- a/tests/test_parsepy.py
+++ b/tests/test_parsepy.py
@@ -130,10 +130,10 @@ class TestParsePy(unittest.TestCase):
       from a import *
       from a.b import *
       from a . b . c import *
-    """), [parsepy.ImportStatement(name='a', is_from=True, everything=True),
-           parsepy.ImportStatement(name='a.b', is_from=True, everything=True),
+    """), [parsepy.ImportStatement(name='a', is_from=True, is_star=True),
+           parsepy.ImportStatement(name='a.b', is_from=True, is_star=True),
            parsepy.ImportStatement(
-               name='a.b.c', is_from=True, everything=True)])
+               name='a.b.c', is_from=True, is_star=True)])
 
     def test_dot(self):
         self.assertEqual(self.parse("""
@@ -145,7 +145,7 @@ class TestParsePy(unittest.TestCase):
            parsepy.ImportStatement(name='.a.b', new_name='b', is_from=True),
            parsepy.ImportStatement(name='.a.b.c', new_name='c', is_from=True),
            parsepy.ImportStatement(
-               name='.a.b.c', is_from=True, everything=True)])
+               name='.a.b.c', is_from=True, is_star=True)])
 
     def test_dotdot(self):
         self.assertEqual(self.parse("""
@@ -157,12 +157,12 @@ class TestParsePy(unittest.TestCase):
            parsepy.ImportStatement(name='..a.b', new_name='b', is_from=True),
            parsepy.ImportStatement(name='..a.b.c', new_name='c', is_from=True),
            parsepy.ImportStatement(
-               name='..a.b.c', is_from=True, everything=True)])
+               name='..a.b.c', is_from=True, is_star=True)])
 
     def test_dotdotdot_asterisk(self):
         self.assertEqual(self.parse("""
       from ... import *
-    """), [parsepy.ImportStatement(name='...', is_from=True, everything=True)])
+    """), [parsepy.ImportStatement(name='...', is_from=True, is_star=True)])
 
     def test_dot_multiple(self):
         self.assertEqual(self.parse("""

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,6 +1,5 @@
 """Tests for resolve.py."""
 
-import os
 import unittest
 
 from importlab import fs

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -150,6 +150,30 @@ class TestResolver(unittest.TestCase):
         self.assertEqual(f.path, "sys.so")
         self.assertEqual(f.module_name, "sys")
 
+    def testResolveStarImport(self):
+        # from foo.c import *
+        imp = parsepy.ImportStatement("foo.c", is_from=True, is_star=True)
+        r = resolve.Resolver(self.path, "x.py")
+        f = r.resolve_import(imp)
+        self.assertEqual(f.path, "foo/c.py")
+        self.assertEqual(f.module_name, "foo.c")
+
+    def testResolveStarImportBuiltin(self):
+        imp = parsepy.ImportStatement("sys", is_from=True, is_star=True)
+        r = resolve.Resolver(self.path, "x.py")
+        f = r.resolve_import(imp)
+        self.assertTrue(isinstance(f, resolve.Builtin))
+        self.assertEqual(f.path, "sys.so")
+        self.assertEqual(f.module_name, "sys")
+
+    def testResolveStarImportSystem(self):
+        imp = parsepy.ImportStatement("f", is_from=True, is_star=True,
+                                      source="/system/f.py")
+        r = resolve.Resolver(self.path, "x.py")
+        f = r.resolve_import(imp)
+        self.assertEqual(f.path, "/system/f.py")
+        self.assertEqual(f.module_name, "f")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -13,7 +13,8 @@ FILES = {
         "b.py": "contents of b",
         "foo/c.py": "contents of c",
         "foo/d.py": "contents of d",
-        "bar/e.py": "contents of e"
+        "bar/e.py": "contents of e",
+        "baz/__init__.py": "contents of init"
 }
 
 
@@ -30,18 +31,21 @@ class TestResolver(unittest.TestCase):
         self.assertTrue(isinstance(f, resolve.Local))
         self.assertEqual(f.fs, self.path[0])
         self.assertEqual(f.path, "a.py")
+        self.assertEqual(f.module_name, "a")
 
     def testResolveTopLevel(self):
         imp = parsepy.ImportStatement("a")
         r = resolve.Resolver(self.path, "b.py")
         f = r.resolve_import(imp)
         self.assertEqual(f.path, "a.py")
+        self.assertEqual(f.module_name, "a")
 
     def testResolvePackageFile(self):
         imp = parsepy.ImportStatement("foo.c")
         r = resolve.Resolver(self.path, "b.py")
         f = r.resolve_import(imp)
         self.assertEqual(f.path, "foo/c.py")
+        self.assertEqual(f.module_name, "foo.c")
 
     def testResolveSamePackageFile(self):
         imp = parsepy.ImportStatement(".c")
@@ -55,13 +59,29 @@ class TestResolver(unittest.TestCase):
         f = r.resolve_import(imp)
         self.assertEqual(f.path, "a.py")
         self.assertTrue(isinstance(f, resolve.Relative))
-        self.assertEqual(f.from_path, "foo/d.py")
+        self.assertEqual(f.module_name, "..a")
 
     def testResolveSiblingPackageFile(self):
         imp = parsepy.ImportStatement("..bar.e")
         r = resolve.Resolver(self.path, "foo/d.py")
         f = r.resolve_import(imp)
         self.assertEqual(f.path, "bar/e.py")
+        self.assertEqual(f.module_name, "..bar.e")
+
+    def testResolveInitFile(self):
+        imp = parsepy.ImportStatement("baz")
+        r = resolve.Resolver(self.path, "b.py")
+        f = r.resolve_import(imp)
+        self.assertEqual(f.path, "baz/__init__.py")
+        self.assertEqual(f.module_name, "baz")
+
+    def testResolveInitFileRelative(self):
+        imp = parsepy.ImportStatement("..baz")
+        r = resolve.Resolver(self.path, "foo/d.py")
+        f = r.resolve_import(imp)
+        self.assertTrue(isinstance(f, resolve.Relative))
+        self.assertEqual(f.path, "baz/__init__.py")
+        self.assertEqual(f.module_name, "..baz")
 
     def testResolveModuleFromFile(self):
         # from foo import c
@@ -69,6 +89,7 @@ class TestResolver(unittest.TestCase):
         r = resolve.Resolver(self.path, "x.py")
         f = r.resolve_import(imp)
         self.assertEqual(f.path, "foo/c.py")
+        self.assertEqual(f.module_name, "foo.c")
 
     def testResolveSymbolFromFile(self):
         # from foo.c import X
@@ -76,12 +97,14 @@ class TestResolver(unittest.TestCase):
         r = resolve.Resolver(self.path, "x.py")
         f = r.resolve_import(imp)
         self.assertEqual(f.path, "foo/c.py")
+        self.assertEqual(f.module_name, "foo.c")
 
     def testOverrideSource(self):
         imp = parsepy.ImportStatement("foo.c", source="/system/c.py")
         r = resolve.Resolver(self.path, "x.py")
         f = r.resolve_import(imp)
         self.assertEqual(f.path, "foo/c.py")
+        self.assertEqual(f.module_name, "foo.c")
 
     def testFallBackToSource(self):
         imp = parsepy.ImportStatement("f", source="/system/f.py")
@@ -89,6 +112,7 @@ class TestResolver(unittest.TestCase):
         f = r.resolve_import(imp)
         self.assertTrue(isinstance(f, resolve.System))
         self.assertEqual(f.path, "/system/f.py")
+        self.assertEqual(f.module_name, "f")
 
     def testGetPyFromPycSource(self):
         # Override a source pyc file with the corresponding py file if it exists
@@ -100,12 +124,14 @@ class TestResolver(unittest.TestCase):
             r = resolve.Resolver(self.path, "x.py")
             f = r.resolve_import(imp)
             self.assertEqual(f.path, py_file)
+            self.assertEqual(f.module_name, "f")
 
     def testPycSourceWithoutPy(self):
         imp = parsepy.ImportStatement("f", source="/system/f.pyc")
         r = resolve.Resolver(self.path, "x.py")
         f = r.resolve_import(imp)
         self.assertEqual(f.path, "/system/f.pyc")
+        self.assertEqual(f.module_name, "f")
 
     def testResolveBuiltin(self):
         imp = parsepy.ImportStatement("sys")
@@ -113,6 +139,7 @@ class TestResolver(unittest.TestCase):
         f = r.resolve_import(imp)
         self.assertTrue(isinstance(f, resolve.Builtin))
         self.assertEqual(f.path, "sys.so")
+        self.assertEqual(f.module_name, "sys")
 
 
 if __name__ == "__main__":

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,5 +1,6 @@
 """Tests for resolve.py."""
 
+import os
 import unittest
 
 from importlab import fs
@@ -23,61 +24,72 @@ class TestResolver(unittest.TestCase):
     def setUp(self):
         self.path = [fs.StoredFileSystem(FILES)]
 
+    def testResolveWithFilesystem(self):
+        imp = parsepy.ImportStatement("a")
+        r = resolve.Resolver(self.path, "b.py")
+        f = r.resolve_import(imp)
+        self.assertTrue(isinstance(f, resolve.Local))
+        self.assertEqual(f.fs, self.path[0])
+        self.assertEqual(f.path, "a.py")
+
     def testResolveTopLevel(self):
         imp = parsepy.ImportStatement("a")
         r = resolve.Resolver(self.path, "b.py")
-        fname = r.resolve_import(imp)
-        self.assertEqual(fname, "a.py")
+        f = r.resolve_import(imp)
+        self.assertEqual(f.path, "a.py")
 
     def testResolvePackageFile(self):
         imp = parsepy.ImportStatement("foo.c")
         r = resolve.Resolver(self.path, "b.py")
-        fname = r.resolve_import(imp)
-        self.assertEqual(fname, "foo/c.py")
+        f = r.resolve_import(imp)
+        self.assertEqual(f.path, "foo/c.py")
 
     def testResolveSamePackageFile(self):
         imp = parsepy.ImportStatement(".c")
         r = resolve.Resolver(self.path, "foo/d.py")
-        fname = r.resolve_import(imp)
-        self.assertEqual(fname, "foo/c.py")
+        f = r.resolve_import(imp)
+        self.assertEqual(f.path, "foo/c.py")
 
     def testResolveParentPackageFile(self):
         imp = parsepy.ImportStatement("..a")
         r = resolve.Resolver(self.path, "foo/d.py")
-        fname = r.resolve_import(imp)
-        self.assertEqual(fname, "a.py")
+        f = r.resolve_import(imp)
+        self.assertEqual(f.path, "a.py")
+        self.assertTrue(isinstance(f, resolve.Relative))
+        self.assertEqual(f.from_path, "foo/d.py")
 
     def testResolveSiblingPackageFile(self):
         imp = parsepy.ImportStatement("..bar.e")
         r = resolve.Resolver(self.path, "foo/d.py")
-        fname = r.resolve_import(imp)
-        self.assertEqual(fname, "bar/e.py")
+        f = r.resolve_import(imp)
+        self.assertEqual(f.path, "bar/e.py")
 
     def testResolveModuleFromFile(self):
         # from foo import c
         imp = parsepy.ImportStatement("foo.c", is_from=True)
         r = resolve.Resolver(self.path, "x.py")
-        fname = r.resolve_import(imp)
-        self.assertEqual(fname, "foo/c.py")
+        f = r.resolve_import(imp)
+        self.assertEqual(f.path, "foo/c.py")
 
     def testResolveSymbolFromFile(self):
         # from foo.c import X
         imp = parsepy.ImportStatement("foo.c.X", is_from=True)
         r = resolve.Resolver(self.path, "x.py")
-        fname = r.resolve_import(imp)
-        self.assertEqual(fname, "foo/c.py")
+        f = r.resolve_import(imp)
+        self.assertEqual(f.path, "foo/c.py")
 
     def testOverrideSource(self):
         imp = parsepy.ImportStatement("foo.c", source="/system/c.py")
         r = resolve.Resolver(self.path, "x.py")
-        fname = r.resolve_import(imp)
-        self.assertEqual(fname, "foo/c.py")
+        f = r.resolve_import(imp)
+        self.assertEqual(f.path, "foo/c.py")
 
     def testFallBackToSource(self):
         imp = parsepy.ImportStatement("f", source="/system/f.py")
         r = resolve.Resolver(self.path, "x.py")
-        fname = r.resolve_import(imp)
-        self.assertEqual(fname, "/system/f.py")
+        f = r.resolve_import(imp)
+        self.assertTrue(isinstance(f, resolve.System))
+        self.assertEqual(f.path, "/system/f.py")
 
     def testGetPyFromPycSource(self):
         # Override a source pyc file with the corresponding py file if it exists
@@ -87,14 +99,21 @@ class TestResolver(unittest.TestCase):
             pyc_file = d.create_file('f.pyc')
             imp = parsepy.ImportStatement("f", source=pyc_file)
             r = resolve.Resolver(self.path, "x.py")
-            fname = r.resolve_import(imp)
-            self.assertEqual(fname, py_file)
+            f = r.resolve_import(imp)
+            self.assertEqual(f.path, py_file)
 
     def testPycSourceWithoutPy(self):
         imp = parsepy.ImportStatement("f", source="/system/f.pyc")
         r = resolve.Resolver(self.path, "x.py")
-        fname = r.resolve_import(imp)
-        self.assertEqual(fname, "/system/f.pyc")
+        f = r.resolve_import(imp)
+        self.assertEqual(f.path, "/system/f.pyc")
+
+    def testResolveBuiltin(self):
+        imp = parsepy.ImportStatement("sys")
+        r = resolve.Resolver(self.path, "x.py")
+        f = r.resolve_import(imp)
+        self.assertTrue(isinstance(f, resolve.Builtin))
+        self.assertEqual(f.path, "sys.so")
 
 
 if __name__ == "__main__":

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -114,6 +114,15 @@ class TestResolver(unittest.TestCase):
         self.assertEqual(f.path, "/system/f.py")
         self.assertEqual(f.module_name, "f")
 
+    def testResolveSystemSymbol(self):
+        imp = parsepy.ImportStatement("argparse.ArgumentParser",
+                                      source="/system/argparse.pyc",
+                                      is_from=True)
+        r = resolve.Resolver(self.path, "x.py")
+        f = r.resolve_import(imp)
+        self.assertTrue(isinstance(f, resolve.System))
+        self.assertEqual(f.module_name, "argparse")
+
     def testGetPyFromPycSource(self):
         # Override a source pyc file with the corresponding py file if it exists
         # in the native filesystem.

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -140,6 +140,16 @@ class TestResolver(unittest.TestCase):
         self.assertTrue(isinstance(f, resolve.System))
         self.assertEqual(f.module_name, "foo.foo")
 
+    def testResolveSystemInitFile(self):
+        # from foo.foo import foo
+        imp = parsepy.ImportStatement("foo.bar.X",
+                                      source="/system/foo/bar/__init__.pyc",
+                                      is_from=True)
+        r = resolve.Resolver(self.path, "x.py")
+        f = r.resolve_import(imp)
+        self.assertTrue(isinstance(f, resolve.System))
+        self.assertEqual(f.module_name, "foo.bar")
+
     def testGetPyFromPycSource(self):
         # Override a source pyc file with the corresponding py file if it exists
         # in the native filesystem.

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -123,6 +123,16 @@ class TestResolver(unittest.TestCase):
         self.assertTrue(isinstance(f, resolve.System))
         self.assertEqual(f.module_name, "argparse")
 
+    def testResolveSystemSymbolNameClash(self):
+        # from foo.foo import foo
+        imp = parsepy.ImportStatement("foo.foo.foo",
+                                      source="/system/bar/foo/foo.pyc",
+                                      is_from=True)
+        r = resolve.Resolver(self.path, "x.py")
+        f = r.resolve_import(imp)
+        self.assertTrue(isinstance(f, resolve.System))
+        self.assertEqual(f.module_name, "foo.foo")
+
     def testGetPyFromPycSource(self):
         # Override a source pyc file with the corresponding py file if it exists
         # in the native filesystem.


### PR DESCRIPTION
When we resolve an import into a filepath, track the mechanism by which we did so (directly added as a source file, builtin, system package, local file, or relative to an existing file).