### PR TITLE
add a current_module to the resolver to resolve relative module names

### DIFF
--- a/importlab/fs.py
+++ b/importlab/fs.py
@@ -153,8 +153,8 @@ class TarFileSystem(object):
 
 
 class Path(object):
-    def __init__(self, paths=[]):
-        self.paths = paths
+    def __init__(self, paths=None):
+        self.paths = paths if paths else []
 
     def add_path(self, path, kind='os'):
         if kind == 'os':

--- a/importlab/fs.py
+++ b/importlab/fs.py
@@ -153,8 +153,8 @@ class TarFileSystem(object):
 
 
 class Path(object):
-    def __init__(self):
-        self.paths = []
+    def __init__(self, paths=[]):
+        self.paths = paths
 
     def add_path(self, path, kind='os'):
         if kind == 'os':

--- a/importlab/fs.py
+++ b/importlab/fs.py
@@ -32,6 +32,14 @@ class FileSystem(with_metaclass(abc.ABCMeta, object)):
         """Get a fully qualified path for the given path."""
         pass
 
+    def relative_path(self, path):
+        """Return the relative path to `path`.
+
+        If this filesystem has a root directory, and path is within that
+        directory tree, return the relative path; otherwise return None.
+        """
+        return None
+
 
 class StoredFileSystem(FileSystem):
     """File system based on a file list."""
@@ -77,6 +85,11 @@ class OSFileSystem(FileSystem):
 
     def refer_to(self, path):
         return self._join(path)
+
+    def relative_path(self, path):
+        if path.startswith(self.root):
+            return path[len(self.root) + 1:]
+        return None
 
 
 class RemappingFileSystem(with_metaclass(abc.ABCMeta, FileSystem)):

--- a/importlab/graph.py
+++ b/importlab/graph.py
@@ -90,35 +90,37 @@ class DependencyGraph(object):
     def get_file_deps(self, filename):
         raise NotImplementedError()
 
-    def _add_source_file(self, filename):
+    def add_source_file(self, filename):
         self.sources.add(filename)
-        self.provenance[filename] = resolve.Direct(filename)
+        self.provenance[filename] = self.get_source_file_provenance(filename)
+
+    def get_source_file_provenance(self, filename):
+        return resolve.Direct(filename)
 
     def add_file(self, filename):
         """Add a file and all its immediate dependencies to the graph."""
 
         assert not self.final, 'Trying to mutate a final graph.'
-        self._add_source_file(filename)
-        resolved, unresolved, provenance = self.get_file_deps(filename)
+        self.add_source_file(filename)
+        resolved, unresolved = self.get_file_deps(filename)
         self.graph.add_node(filename)
         for f in resolved:
             self.graph.add_node(f)
             self.graph.add_edge(filename, f)
         for imp in unresolved:
             self.broken_deps[filename].add(imp)
-        self.provenance.update(provenance)
 
     def add_file_recursive(self, filename):
         """Add a file and all its recursive dependencies to the graph."""
 
         assert not self.final, 'Trying to mutate a final graph.'
-        self._add_source_file(filename)
+        self.add_source_file(filename)
         queue = collections.deque([filename])
         seen = set()
         while queue:
             filename = queue.popleft()
             self.graph.add_node(filename)
-            deps, broken, provenance = self.get_file_deps(filename)
+            deps, broken = self.get_file_deps(filename)
             for f in broken:
                 self.broken_deps[filename].add(f)
             for f in deps:
@@ -129,7 +131,6 @@ class DependencyGraph(object):
                     seen.add(f)
                 self.graph.add_node(f)
                 self.graph.add_edge(filename, f)
-            self.provenance.update(provenance)
 
     def extract_cycle(self, cycle):
         assert not self.final, 'Trying to mutate a final graph.'
@@ -248,18 +249,24 @@ class ImportGraph(DependencyGraph):
         import_graph.build()
         return import_graph
 
+    def get_source_file_provenance(self, filename):
+        """Infer the module name if possible."""
+        module_name = resolve.infer_module_name(filename, self.path)
+        return resolve.Direct(filename, module_name)
+
     def get_file_deps(self, filename):
         r = resolve.Resolver(self.path, filename)
         resolved = []
         unresolved = []
-        provenance = {}
+        parent = self.provenance[filename]
         for imp in parsepy.get_imports(filename, self.env.python_version):
             try:
-                f = r.resolve_import(imp)
-                if not f.is_extension():
-                    full_path = os.path.abspath(f.path)
-                    resolved.append(full_path)
-                    provenance[full_path] = f
+                f = r.resolve_import(imp, parent)
+                if f.is_extension():
+                    continue
+                full_path = os.path.abspath(f.path)
+                resolved.append(full_path)
+                self.provenance[full_path] = f
             except resolve.ImportException:
                 unresolved.append(imp)
-        return (resolved, unresolved, provenance)
+        return (resolved, unresolved)

--- a/importlab/graph.py
+++ b/importlab/graph.py
@@ -255,10 +255,10 @@ class ImportGraph(DependencyGraph):
         return resolve.Direct(filename, module_name)
 
     def get_file_deps(self, filename):
-        r = resolve.Resolver(self.path, filename)
         resolved = []
         unresolved = []
         parent = self.provenance[filename]
+        r = resolve.Resolver(self.path, filename, parent)
         for imp in parsepy.get_imports(filename, self.env.python_version):
             try:
                 f = r.resolve_import(imp)

--- a/importlab/graph.py
+++ b/importlab/graph.py
@@ -261,7 +261,7 @@ class ImportGraph(DependencyGraph):
         parent = self.provenance[filename]
         for imp in parsepy.get_imports(filename, self.env.python_version):
             try:
-                f = r.resolve_import(imp, parent)
+                f = r.resolve_import(imp)
                 if f.is_extension():
                     continue
                 full_path = os.path.abspath(f.path)

--- a/importlab/graph.py
+++ b/importlab/graph.py
@@ -258,7 +258,7 @@ class ImportGraph(DependencyGraph):
         resolved = []
         unresolved = []
         parent = self.provenance[filename]
-        r = resolve.Resolver(self.path, filename, parent)
+        r = resolve.Resolver(self.path, parent)
         for imp in parsepy.get_imports(filename, self.env.python_version):
             try:
                 f = r.resolve_import(imp)

--- a/importlab/output.py
+++ b/importlab/output.py
@@ -24,10 +24,7 @@ def format_file_node(import_graph, node, indent):
     if isinstance(f, resolve.Direct):
         out = '+ ' + f.short_path
     elif isinstance(f, resolve.Local):
-        out = os.path.relpath(f.path, f.fs.path)
-    elif isinstance(f, resolve.Relative):
-        # TODO(martindemello): Format depending on provenance[f.from_path]
-        out = '. ' + f.short_path
+        out = '  ' + os.path.relpath(f.path, f.fs.path)
     elif isinstance(f, resolve.System):
         out = ':: ' + f.short_path
     elif isinstance(f, resolve.Builtin):

--- a/importlab/output.py
+++ b/importlab/output.py
@@ -22,7 +22,7 @@ def format_file_node(import_graph, node, indent):
     """Prettyprint nodes based on their provenance."""
     f = import_graph.provenance[node]
     if isinstance(f, resolve.Direct):
-        out = f.path
+        out = '+ ' + f.short_path
     elif isinstance(f, resolve.Local):
         out = os.path.relpath(f.path, f.fs.path)
     elif isinstance(f, resolve.Relative):

--- a/importlab/output.py
+++ b/importlab/output.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import networkx as nx
-import os
 
 from . import graph
 from . import resolve

--- a/importlab/output.py
+++ b/importlab/output.py
@@ -24,7 +24,7 @@ def format_file_node(import_graph, node, indent):
     if isinstance(f, resolve.Direct):
         out = '+ ' + f.short_path
     elif isinstance(f, resolve.Local):
-        out = '  ' + os.path.relpath(f.path, f.fs.path)
+        out = '  ' + f.short_path
     elif isinstance(f, resolve.System):
         out = ':: ' + f.short_path
     elif isinstance(f, resolve.Builtin):

--- a/importlab/resolve.py
+++ b/importlab/resolve.py
@@ -189,6 +189,8 @@ class Resolver:
                 if item.is_relative():
                     module_name = get_absolute_name(
                             self.current_module.package_name, module_name)
+                    if isinstance(self.current_module, System):
+                        return System(f, module_name)
                 return Local(f, module_name, fs)
 
         # If the module isn't found in the explicit pythonpath, see if python

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,65 @@
+"""Tests for output.py."""
+
+import contextlib
+import io
+import unittest
+
+from importlab import environment
+from importlab import fs
+from importlab import graph
+from importlab import output
+from importlab import utils
+
+
+FILES = {
+        "foo/a.py": "from . import b",
+        "foo/b.py": "pass",
+        "x.py": "import foo.a",
+        "y.py": "import sys",
+        "z.py": "import unresolved"
+}
+
+
+class TestOutput(unittest.TestCase):
+    """Basic sanity tests for output methods."""
+
+    def setUp(self):
+        self.tempdir = utils.Tempdir()
+        self.tempdir.setup()
+        filenames = [
+            self.tempdir.create_file(f, FILES[f])
+            for f in FILES]
+        self.fs = fs.OSFileSystem(self.tempdir.path)
+        env = environment.Environment(fs.Path([self.fs]), (3, 6))
+        self.graph = graph.ImportGraph.create(env, filenames)
+
+    def tearDown(self):
+        self.tempdir.teardown()
+
+    def assertString(self, val):
+        self.assertTrue(isinstance(val, str))
+
+    def assertPrints(self, fn):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            fn(self.graph)
+        self.assertTrue(out.getvalue())
+
+    def test_inspect_graph(self):
+        self.assertPrints(output.inspect_graph)
+
+    def test_print_tree(self):
+        self.assertPrints(output.print_tree)
+
+    def test_print_topological_sort(self):
+        self.assertPrints(output.print_topological_sort)
+
+    def test_formatted_deps_list(self):
+        self.assertString(output.formatted_deps_list(self.graph))
+
+    def test_print_unresolved(self):
+        self.assertPrints(output.print_unresolved_dependencies)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -240,8 +240,8 @@ class TestResolver(unittest.TestCase):
         with utils.Tempdir() as d:
             os_fs = fs.OSFileSystem(d.path)
             fspath = [os_fs]
-            py_file = d.create_file("foo/x.py")
-            py_file = d.create_file("foo/y.py")
+            d.create_file("foo/x.py")
+            d.create_file("foo/y.py")
             imp = parsepy.ImportStatement(".y")
             module = resolve.System(d["foo/x.py"], "foo.x")
             r = resolve.Resolver(fspath, module)

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -236,6 +236,20 @@ class TestResolver(unittest.TestCase):
         self.assertEqual(f.path, "x.pyi")
         self.assertEqual(f.module_name, "x")
 
+    def testResolveSystemRelative(self):
+        with utils.Tempdir() as d:
+            os_fs = fs.OSFileSystem(d.path)
+            fspath = [os_fs]
+            py_file = d.create_file("foo/x.py")
+            py_file = d.create_file("foo/y.py")
+            imp = parsepy.ImportStatement(".y")
+            module = resolve.System(d["foo/x.py"], "foo.x")
+            r = resolve.Resolver(fspath, module)
+            f = r.resolve_import(imp)
+            self.assertEqual(f.path, d["foo/y.py"])
+            self.assertTrue(isinstance(f, resolve.System))
+            self.assertEqual(f.module_name, "foo.y")
+
 
 class TestResolverUtils(unittest.TestCase):
     """Tests for utility functions."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+"""Tests for utils.py."""
+
+import unittest
+
+from importlab import utils
+
+
+class TestUtils(unittest.TestCase):
+    """Tests for utils."""
+
+    def test_strip_suffix(self):
+        a = 'foo bar bar'
+        self.assertEqual(a, utils.strip_suffix(a, 'hello'))
+        self.assertEqual('foo bar ', utils.strip_suffix(a, 'bar'))
+        self.assertEqual(a, utils.strip_suffix(a, 'hbar'))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Tries to infer the module name for directly added files (relative to the specified pythonpath), so that at the time we create a Resolver, we have a module (a ResolvedFile instance) to use to qualify relative module names.