### PR TITLE
Don't allow relative imports in non-packages.

### DIFF
--- a/importlab/resolve.py
+++ b/importlab/resolve.py
@@ -40,8 +40,10 @@ class ResolvedFile(object):
         f, _ = os.path.splitext(self.path)
         if f.endswith('__init__'):
             return self.module_name
+        elif '.' in self.module_name:
+            return self.module_name[:self.module_name.rindex('.')]
         else:
-            return self.module_name[:self.module_name.rfind('.')]
+            return None
 
     @property
     def short_path(self):
@@ -187,8 +189,11 @@ class Resolver:
                 if not f:
                     continue
                 if item.is_relative():
-                    module_name = get_absolute_name(
-                            self.current_module.package_name, module_name)
+                    package_name = self.current_module.package_name
+                    if package_name is None:
+                        # Relative import in non-package
+                        raise ImportException(name)
+                    module_name = get_absolute_name(package_name, module_name)
                     if isinstance(self.current_module, System):
                         return System(f, module_name)
                 return Local(f, module_name, fs)

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -250,6 +250,12 @@ class TestResolver(unittest.TestCase):
             self.assertTrue(isinstance(f, resolve.System))
             self.assertEqual(f.module_name, "foo.y")
 
+    def testResolveRelativeInNonPackage(self):
+        r = self.make_resolver("a.py", "a")
+        imp = parsepy.ImportStatement(".b", is_from=True)
+        with self.assertRaises(resolve.ImportException):
+            r.resolve_import(imp)
+
 
 class TestResolverUtils(unittest.TestCase):
     """Tests for utility functions."""


### PR DESCRIPTION
Previously, in a non-package (i.e., the module name contains no
dots), package_name() would be the module name minus the final
character, so module 'test' had package 'tes', leading to bizarre
names for relative imports. Instead, a relative import in a
non-package should be considered unresolved.