### PR TITLE
Add pytype to importlab.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+os: linux
+
+sudo: enabled
+
+language: python
+
+python:
+  - "2.7"
+  - "3.6"
+
+before_install:
+  # We need to install python-3.6 from a third party repo as it is not
+  # available as a standard package on Travis Trusty VMs.
+  - sudo add-apt-repository ppa:jonathonf/python-3.6 -y
+  - sudo apt-get update -q
+  - sudo apt-get install python3.6
+  - sudo apt-get install python3.6-dev
+
+install:
+  - pip install networkx
+  - pip install six
+  - pip install pytype
+
+# Use one long command so that the build will fail on the first error:
+# https://github.com/travis-ci/travis-ci/issues/1066.
+script: |
+  pytype -V2.7 . --exclude tests/ testdata/ &&
+  pytype -V3.6 . --exclude tests/ testdata/ &&
+  ./tests/run_all.sh

--- a/importlab/graph.py
+++ b/importlab/graph.py
@@ -1,7 +1,7 @@
 import collections
 import os
 
-import networkx as nx
+import networkx as nx  # pytype: disable=import-error
 
 from . import resolve
 from . import parsepy

--- a/importlab/import_finder.py
+++ b/importlab/import_finder.py
@@ -9,7 +9,9 @@ import json
 import os
 import sys
 
-if sys.version_info.major >= 3:
+# Pytype doesn't recognize the `major` attribute:
+# https://github.com/google/pytype/issues/127.
+if sys.version_info[0] >= 3:
     import importlib
 else:
     import imp
@@ -87,7 +89,9 @@ def _resolve_import(name):
     if name in sys.modules:
         return getattr(sys.modules[name], '__file__', name + '.so')
 
-    if sys.version_info.major >= 3:
+    # Pytype doesn't recognize the `major` attribute:
+    # https://github.com/google/pytype/issues/127.
+    if sys.version_info[0] >= 3:
         return _resolve_import_3(name)
     else:
         return _resolve_import_2(name)

--- a/importlab/output.py
+++ b/importlab/output.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-import networkx as nx
+import networkx as nx  # pytype: disable=import-error
 
 from . import graph
 from . import resolve

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,5 @@ exclude =
   build/
   dist/
   testdata/
+
+[pytype]

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -1,0 +1,7 @@
+# This script must be run from the directory above tests.
+python -m tests.test_fs
+python -m tests.test_graph
+python -m tests.test_output
+python -m tests.test_parsepy
+python -m tests.test_resolve
+python -m tests.test_utils

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -2,6 +2,8 @@
 
 import contextlib
 import io
+import six
+import sys
 import unittest
 
 from importlab import environment
@@ -18,6 +20,17 @@ FILES = {
         "y.py": "import sys",
         "z.py": "import unresolved"
 }
+
+
+# For Python 2 compatibility, since contextlib.redirect_stdout is 3-only.
+@contextlib.contextmanager
+def redirect_stdout(out):
+  old = sys.stdout
+  sys.stdout = out
+  try:
+    yield
+  finally:
+    sys.stdout = old
 
 
 class TestOutput(unittest.TestCase):
@@ -40,8 +53,8 @@ class TestOutput(unittest.TestCase):
         self.assertTrue(isinstance(val, str))
 
     def assertPrints(self, fn):
-        out = io.StringIO()
-        with contextlib.redirect_stdout(out):
+        out = six.StringIO()
+        with redirect_stdout(out):
             fn(self.graph)
         self.assertTrue(out.getvalue())
 


### PR DESCRIPTION
* Makes all importlab code outside of tests/ and testdata/ compatible
  with pytype.
* Adds a [pytype] section to setup.cfg. This is empty for now, but the
  inputs and excludes will eventually be stored here rather than going
  on the command line.
* Adds a tests/run_all.sh, both for easily running all tests locally and
  for a travis config's use.
* Adds a travis config in Python 2.7 and Python 3.6 that runs pytype,
  then importlab's tests.
* Makes the importlab tests 2-and-3 compatible.

FYI, I modeled the .travis.yml file on pytype's; I don't know how to verify it works. I did install and run travis-lint, so it's at least syntactically correct.