### PR TITLE
Fix the travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ install:
 
 # Use one long command so that the build will fail on the first error:
 # https://github.com/travis-ci/travis-ci/issues/1066.
+# Run pytype with the same host and target versions so that all of
+# importlab's dependencies are present.
 script: |
-  pytype -V2.7 . --exclude tests/ testdata/ &&
-  pytype -V3.6 . --exclude tests/ testdata/ &&
+  pytype -V$TRAVIS_PYTHON_VERSION . --exclude tests/ testdata/ &&
   ./tests/run_all.sh

--- a/importlab/graph.py
+++ b/importlab/graph.py
@@ -1,7 +1,8 @@
 import collections
 import os
 
-import networkx as nx  # pytype: disable=import-error
+# Workaround for https://github.com/google/pytype/issues/128.
+import networkx as nx  # type: ignore
 
 from . import resolve
 from . import parsepy

--- a/importlab/import_finder.py
+++ b/importlab/import_finder.py
@@ -74,7 +74,7 @@ def _resolve_import_2(name):
 def _resolve_import_3(name):
     """Helper function for resolve_import."""
     try:
-        spec = importlib.util.find_spec(name)
+        spec = importlib.util.find_spec(name)  # pytype: disable=module-attr
         if spec:
             return spec.origin
     except AttributeError:

--- a/importlab/output.py
+++ b/importlab/output.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
-import networkx as nx  # pytype: disable=import-error
+# Workaround for https://github.com/google/pytype/issues/128.
+import networkx as nx  # type: ignore
 
 from . import graph
 from . import resolve

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import io
 import os
 
-from setuptools import find_packages, setup
+from setuptools import find_packages, setup  # pytype: disable=import-error
 
 # Package meta-data.
 NAME = 'importlab'


### PR DESCRIPTION
* Silence two findings: pytype can't find setuptools in py2 and reports
  an attribute error inside a try/except AttributeError block.
* Change the disable comment on networkx to `# type: ignore` to avoid
  tripping a pytype bug.
* Always run pytype with the same host and target python versions.
  Unfortunately, this doesn't help us pick up setuptools in py2 or
  handle networkx properly, but it's the right thing to do.