### PR TITLE
Another pytype fix.

### DIFF
--- a/importlab/fs.py
+++ b/importlab/fs.py
@@ -2,7 +2,9 @@ import abc
 import os
 import tarfile
 
-from six import with_metaclass
+# https://github.com/google/pytype/issues/128
+from six import with_metaclass  # pytype: disable=pyi-error
+# pytype: disable=ignored-abstractmethod
 
 
 class FileSystemError(Exception):

--- a/importlab/graph.py
+++ b/importlab/graph.py
@@ -1,8 +1,7 @@
 import collections
 import os
 
-# Workaround for https://github.com/google/pytype/issues/128.
-import networkx as nx  # type: ignore
+import networkx as nx
 
 from . import resolve
 from . import parsepy

--- a/importlab/output.py
+++ b/importlab/output.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
-# Workaround for https://github.com/google/pytype/issues/128.
-import networkx as nx  # type: ignore
+import networkx as nx
 
 from . import graph
 from . import resolve


### PR DESCRIPTION
The networkx bug was flaky, since it depended on whether fs.py is analyzed
before or after the networkx imports, which tricked me into thinking an
incorrect fix was working. Replaces it with a hopefully correct one.