### PR TITLE
Handle unreadable files when host and target Python versions match.

### DIFF
--- a/importlab/parsepy.py
+++ b/importlab/parsepy.py
@@ -24,11 +24,7 @@ from . import runner
 
 class ParseError(Exception):
     """Error parsing a file with python."""
-
-    def __init__(self, filename, msg=None):
-        self.filename = filename
-        self.msg = msg
-        super(ParseError, self).__init__(filename, msg)
+    pass
 
 
 class ImportStatement(collections.namedtuple(
@@ -83,7 +79,7 @@ def get_imports(filename, python_version):
         try:
             imports = import_finder.get_imports(filename)
         except Exception as e:
-            raise ParseError(filename, str(e))
+            raise ParseError(filename)
     else:
         # Call the appropriate python version in a subprocess
         f = sys.modules['importlab.import_finder'].__file__

--- a/importlab/parsepy.py
+++ b/importlab/parsepy.py
@@ -24,7 +24,11 @@ from . import runner
 
 class ParseError(Exception):
     """Error parsing a file with python."""
-    pass
+
+    def __init__(self, filename, msg=None):
+        self.filename = filename
+        self.msg = msg
+        super(ParseError, self).__init__(filename, msg)
 
 
 class ImportStatement(collections.namedtuple(
@@ -76,7 +80,10 @@ class ImportStatement(collections.namedtuple(
 def get_imports(filename, python_version):
     if python_version == sys.version_info[0:2]:
         # Invoke import_finder directly
-        imports = import_finder.get_imports(filename)
+        try:
+            imports = import_finder.get_imports(filename)
+        except Exception as e:
+            raise ParseError(filename, str(e))
     else:
         # Call the appropriate python version in a subprocess
         f = sys.modules['importlab.import_finder'].__file__

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -40,7 +40,7 @@ class FakeImportGraph(graph.DependencyGraph):
 
     def get_file_deps(self, filename):
         if filename in self.unreadable:
-            raise parsepy.ParseError()
+            raise parsepy.ParseError(filename)
         if filename in self.deps:
             resolved, unresolved, provenance = self.deps[filename]
             self.provenance.update(provenance)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -40,7 +40,7 @@ class FakeImportGraph(graph.DependencyGraph):
 
     def get_file_deps(self, filename):
         if filename in self.unreadable:
-            raise parsepy.ParseError(filename)
+            raise parsepy.ParseError()
         if filename in self.deps:
             resolved, unresolved, provenance = self.deps[filename]
             self.provenance.update(provenance)

--- a/tests/test_parsepy.py
+++ b/tests/test_parsepy.py
@@ -211,6 +211,10 @@ class TestParsePy(unittest.TestCase):
         self.assertRaises(UnicodeDecodeError, unicode, src)  # noqa: F821
         self.assertEqual(self.parse(src), [])
 
+    def test_syntax_error(self):
+        with self.assertRaises(parsepy.ParseError):
+            self.parse("foo(]")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Importlab was still crashing on syntax errors when import_finder was invoked directly.