### PR TITLE
Strip `__init__` from inferred module names.

### DIFF
--- a/importlab/resolve.py
+++ b/importlab/resolve.py
@@ -102,8 +102,9 @@ def infer_module_name(filename, fspath):
     for f in fspath:
         short_name = f.relative_path(filename)
         if short_name:
-            if short_name.endswith("/__init__"):
-                short_name = short_name[:short_name.rfind('/')]
+            # The module name for __init__.py files is the directory.
+            if short_name.endswith(os.path.sep + "__init__"):
+                short_name = short_name[:short_name.rfind(os.path.sep)]
             return short_name.replace(os.path.sep, '.')
     # We have not found filename relative to anywhere in pythonpath.
     return ''

--- a/importlab/resolve.py
+++ b/importlab/resolve.py
@@ -102,6 +102,8 @@ def infer_module_name(filename, fspath):
     for f in fspath:
         short_name = f.relative_path(filename)
         if short_name:
+            if short_name.endswith("/__init__"):
+                short_name = short_name[:short_name.rfind('/')]
             return short_name.replace(os.path.sep, '.')
     # We have not found filename relative to anywhere in pythonpath.
     return ''

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -293,6 +293,15 @@ class TestResolverUtils(unittest.TestCase):
                     resolve.infer_module_name("/some/random/file", fspath),
                     "")
 
+    def testInferInitModuleName(self):
+        with utils.Tempdir() as d:
+            os_fs = fs.OSFileSystem(d.path)
+            fspath = [os_fs]
+            py_file = d.create_file("foo/__init__.py")
+            self.assertEqual(
+                    resolve.infer_module_name(py_file, fspath),
+                    "foo")
+
     def testGetAbsoluteName(self):
         test_cases = [
                 ("x.y", "a.b", "x.y.a.b"),


### PR DESCRIPTION
Closes #22 and closes google/pytype#154.