### PR TITLE
Handle `from . import Symbol` style of relative imports.

### DIFF
--- a/importlab/resolve.py
+++ b/importlab/resolve.py
@@ -129,8 +129,10 @@ def get_absolute_name(package, relative_name):
     ndots = len(relative_name) - len(name)
     if ndots > len(path):
         return relative_name
-    prefix = ''.join([p + '.' for p in path[:len(path) + 1 - ndots]])
-    return prefix + name
+    absolute_path = path[:len(path) + 1 - ndots]
+    if name:
+        absolute_path.append(name)
+    return '.'.join(absolute_path)
 
 
 class Resolver:
@@ -168,7 +170,13 @@ class Resolver:
         # module, so we try a.b.c and a.b.c.d as names.
         short_name = None
         if item.is_from and not item.is_star:
-            short_name = name[:name.rfind('.')]
+            if '.' in name.lstrip('.'):
+                # The name is something like `a.b.c`, so strip off `.c`.
+                rindex = name.rfind('.')
+            else:
+                # The name is something like `..c`, so strip off just `c`.
+                rindex = name.rfind('.') + 1
+            short_name = name[:rindex]
 
         if import_finder.is_builtin(name):
             filename = name + '.so'

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -116,6 +116,16 @@ class TestResolver(unittest.TestCase):
         self.assertEqual(f.path, "baz/f.py")
         self.assertEqual(f.module_name, "baz.f")
 
+    def testResolveRelativeSymbol(self):
+        # importing the Symbol object from baz/__init__.py while in baz/f.py
+        parent = resolve.Direct("baz/f.py", "baz.f")
+        imp = parsepy.ImportStatement(".Symbol", is_from=True)
+        r = resolve.Resolver(self.path, parent)
+        f = r.resolve_import(imp)
+        self.assertTrue(isinstance(f, resolve.Local))
+        self.assertEqual(f.path, "baz/__init__.py")
+        self.assertEqual(f.module_name, "baz")
+
     def testResolveModuleFromFile(self):
         # from foo import c
         imp = parsepy.ImportStatement("foo.c", is_from=True)


### PR DESCRIPTION
Fixes a bug I found while trying to run pytype over mercurial. To reproduce:
```
hg clone https://www.mercurial-scm.org/repo/hg/
cd hg
importlab --tree --trim mercurial/thirdparty/zope
```
The short path for `mercurial/thirdparty/zope/interface/__init__.py` starts at the directory above `hg` rather than at `mercurial` like the rest. Printing out the ResolvedFile object shows further weirdness like a module name of `mercurial.thirdparty.zope.interface.common.`.