### PR TITLE
Fix a broken import.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Version 0.5.1 (2019-05-24)
+* FIX: Correct a broken import
+
 Version 0.5 (2018-12-26)
 * Support `from . import Symbol` style of relative imports
 * Set the default target Python version to the host version

--- a/importlab/import_finder.py
+++ b/importlab/import_finder.py
@@ -12,7 +12,21 @@ import sys
 # Pytype doesn't recognize the `major` attribute:
 # https://github.com/google/pytype/issues/127.
 if sys.version_info[0] >= 3:
-    import importlib
+    # Note that `import importlib` does not work: accessing `importlib.util`
+    # will give an attribute error. This is hard to reproduce in a unit test but
+    # can be seen by install importlab in a Python 3 environment and running
+    # `importlab --tree --trim` on a file that imports one of:
+    #   * jsonschema (`pip install jsonschema`)
+    #   * pytype (`pip install pytype`),
+    #   * dotenv (`pip install python-dotenv`)
+    #   * IPython (`pip install ipython`)
+    # A correct output will look like:
+    #   Reading 1 files
+    #   Source tree:
+    #   + foo.py
+    #       :: jsonschema/__init__.py
+    # An incorrect output will be missing the line with the import.
+    import importlib.util
 else:
     import imp
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ URL = 'https://github.com/google/importlab'
 EMAIL = 'pytype-dev@google.com'
 AUTHOR = 'Google Inc.'
 REQUIRES_PYTHON = '>=2.7.0'
-VERSION = '0.5'
+VERSION = '0.5.1'
 
 REQUIRED = [
     'networkx',


### PR DESCRIPTION
I couldn't reproduce this in a test - whenever I called importlab
as a library, the import worked correctly, but it was broken when
I called importlab as a binary. I left a long comment to minimize
the chance of someone changing the import without testing first.

Fixes https://github.com/google/pytype/issues/318.