### PR TITLE
Require networkx>=2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ REQUIRES_PYTHON = '>=2.7.0'
 VERSION = '0.5.1'
 
 REQUIRED = [
-    'networkx',
+    'networkx>=2',
     'six'
 ]
 


### PR DESCRIPTION
I was trying to use pytype (which has importlab as a dependency) and ran into the following error:
```
Traceback (most recent call last):
  File "/usr/local/bin/pytype", line 11, in <module>
    load_entry_point('pytype==2019.5.24', 'console_scripts', 'pytype')()
  File "/usr/local/lib/python3.6/dist-packages/pytype/tools/analyze_project/main.py", line 77, in main
    import_graph = importlab.graph.ImportGraph.create(env, conf.inputs, trim=True)
  File "/usr/local/lib/python3.6/dist-packages/importlab/graph.py", line 227, in create
    import_graph.add_file_recursive(os.path.abspath(filename), trim)
  File "/usr/local/lib/python3.6/dist-packages/importlab/graph.py", line 119, in add_file_recursive
    if self.follow_file(f, seen, trim):
  File "/usr/local/lib/python3.6/dist-packages/importlab/graph.py", line 83, in follow_file
    return (f not in self.graph.nodes and
TypeError: argument of type 'method' is not iterable
```
The reason was that I had an older version of networkx already installed (maybe see [here](https://networkx.github.io/documentation/stable/release/migration_guide_from_1.x_to_2.0.html)).