### PR TITLE
Detect .so files when --notrim is specified.

### DIFF
--- a/importlab/graph.py
+++ b/importlab/graph.py
@@ -108,7 +108,7 @@ class DependencyGraph(object):
                 # Python file, we mark it as unreadable and keep the node in the
                 # graph so importlab's callers can do their own syntax error
                 # handling if desired.
-                if filename.endswith('.py'):
+                if os.path.splitext(filename)[1] in ('.py', '.so'):
                     self.unreadable_files.add(filename)
                 else:
                     self.graph.remove_node(filename)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -259,6 +259,20 @@ class TestImportGraph(unittest.TestCase):
             foo_a = os.path.splitext(self.tempdir["foo/a.py"])[0] + ".so"
             self.assertEqual(g.sorted_source_files(), [[self.tempdir["x.py"]]])
 
+    def test_system_extension_notrim(self):
+        """Tests that failing to descend into a .so file's deps is ok."""
+        sources = [self.tempdir["x.py"]]
+        def mock_resolve_file(f):
+            path = os.path.splitext(f.path)[0] + ".so"
+            return resolve.System(path, f.module_name)
+        with open(self.tempdir["foo/a.py"], "w") as f:
+          f.write("syntax_error:")  # simulate an unparseable .so file
+        with self.patch_resolve_import(mock_resolve_file):
+            g = graph.ImportGraph.create(self.env, sources, trim=False)
+            foo_a = os.path.splitext(self.tempdir["foo/a.py"])[0] + ".so"
+            self.assertEqual(g.sorted_source_files(),
+                             [[foo_a], [self.tempdir["x.py"]]])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As it turns out, my previous PR only fixed .so file detection when
importlab is run with the --trim option. (pytype always uses --trim.)
When --notrim (the default) is used, importlab was trying to parse the
.so file, failing, and then removing it from the dependency graph.