### PR TITLE
Fix resolution for case-insensitive filesystems

### DIFF
--- a/importlab/fs.py
+++ b/importlab/fs.py
@@ -1,13 +1,17 @@
 import abc
+import glob
 import os
 import tarfile
+import tempfile
+
+from six import with_metaclass
 
 
 class FileSystemError(Exception):
     pass
 
 
-class FileSystem(abc.ABC):
+class FileSystem(with_metaclass(abc.ABCMeta, object)):
     """Interface for file systems."""
 
     @abc.abstractmethod
@@ -65,17 +69,26 @@ class OSFileSystem(FileSystem):
     def __init__(self, root):
         assert root is not None
         self.root = root
+        _, tmp_path = tempfile.mkstemp()
+        self._is_case_insensitive = os.path.exists(tmp_path.upper())
 
     def _join(self, path):
         return os.path.join(self.root, path)
 
+    def _matches_path(self, path):
+        if self._is_case_insensitive:
+            return path in glob.glob(path+'*')
+        return True
+
     def isfile(self, path):
         assert path is not None
-        return os.path.isfile(self._join(path))
+        fullpath = self._join(path)
+        return os.path.isfile(fullpath) and self._matches_path(fullpath)
 
     def isdir(self, path):
         assert path is not None
-        return os.path.isdir(self._join(path))
+        fullpath = self._join(path)
+        return os.path.isdir(fullpath) and self._matches_path(fullpath)
 
     def read(self, path):
         with open(self._join(path), 'r') as fi:
@@ -90,7 +103,7 @@ class OSFileSystem(FileSystem):
         return None
 
 
-class RemappingFileSystem(FileSystem, abc.ABC):
+class RemappingFileSystem(with_metaclass(abc.ABCMeta, FileSystem)):
     """File system wrapper that transforms a path before looking it up."""
 
     def __init__(self, underlying):

--- a/importlab/fs.py
+++ b/importlab/fs.py
@@ -4,14 +4,12 @@ import os
 import tarfile
 import tempfile
 
-from six import with_metaclass
-
 
 class FileSystemError(Exception):
     pass
 
 
-class FileSystem(with_metaclass(abc.ABCMeta, object)):
+class FileSystem(abc.ABC):
     """Interface for file systems."""
 
     @abc.abstractmethod
@@ -103,7 +101,7 @@ class OSFileSystem(FileSystem):
         return None
 
 
-class RemappingFileSystem(with_metaclass(abc.ABCMeta, FileSystem)):
+class RemappingFileSystem(FileSystem, abc.ABC):
     """File system wrapper that transforms a path before looking it up."""
 
     def __init__(self, underlying):


### PR DESCRIPTION
On case-insensitive filesystems like that of macOS, `os.path.isfile(...)`
returns true regardless of the case used for names. This can result in an error
condition if resolved symbols have case-insensitive overlap.

For example, `foo.bar.baz` and `foo.bar.Baz` as can be true in the following
module structure:

```
foo
└── bar
    ├── baz.py
    └── __init__.py
```

When `foo.bar.Baz` is tested for whether it exists at `foo/bar/Baz.py`, the
existing logic would incorrectly surmise that it does exist and that it
corresponds to the relevant module `baz`.

Testing for an exact match on case-insensitive systems is difficult but listing
the directory returns the preserved case of the original file which can be
expected to match the real module's casing per Python's documented behavior:
https://www.python.org/dev/peps/pep-0235/.

Addresses https://github.com/google/pytype/issues/661