### PR TITLE
Use ImportStatement.source to improve import resolution.

### DIFF
--- a/importlab/resolve.py
+++ b/importlab/resolve.py
@@ -185,8 +185,25 @@ class Resolver:
             filename = os.path.normpath(
                 os.path.join(self.current_directory, filename))
 
-        files = [(name, filename)]
-        if short_name:
+        if not short_name:
+            try_filename = True
+            try_short_filename = False
+        elif item.source:
+            # If the import has a source path, we can use it to eliminate
+            # filenames that don't match.
+            source_filename, _ = os.path.splitext(item.source)
+            dirname, basename = os.path.split(source_filename)
+            if basename == "__init__":
+                source_filename = dirname
+            try_filename = source_filename.endswith(filename)
+            try_short_filename = not try_filename
+        else:
+            try_filename = try_short_filename = True
+
+        files = []
+        if try_filename:
+            files.append((name, filename))
+        if try_short_filename:
             short_filename = os.path.dirname(filename)
             files.append((short_name, short_filename))
 


### PR DESCRIPTION
We were doing things like using typeshed's google/cloud/__init__.pyi stub to resolve imports like `from google.cloud import spanner`. We can use the import statement's `source` attribute to figure out that spanner is a module and therefore shouldn't be resolved in this way.

Hypothetically, someone might write stubs for a package that intentionally lie about the directory structure, in which case this new behavior could cause issues. But I think overall it should be an improvement, since we're currently generating spurious errors for everything in the google.cloud namespace.

For https://github.com/google/pytype/issues/1081 and https://github.com/google/pytype/issues/1287.