### PR TITLE
Use latest setuptools practice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 build/
 dist/
+.venv*
+*.egg-info/

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.8.1 (TBC)
+* Change script into entry point.
+* Avoid deprecated setup.py commands.
+
 Version 0.8 (2022-09-22)
 * Add --version to bin importlab.
 * Use ImportStatement.source to impove import resolution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,15 +29,15 @@ To release to PyPI:
    $ python3 -m venv .venv_release
    $ source .venv_release/bin/activate
    ```
-1. Make sure that `wheel` and `twine` are installed:
+1. Make sure that `build`, `wheel` and `twine` are installed:
    ```console
-   $ pip install wheel twine
+   $ pip install build wheel twine
    ```
 1. Navigate into the top-level `importlab` directory and build a source
    distribution and a wheel:
    ```console
    $ cd importlab
-   $ python3 setup.py sdist bdist_wheel
+   $ python3 -m build
    ```
    The build command puts the distributions in a `dist` subdirectory and also
    creates `build` and `importlab.egginfo` subdirectories as side effects.

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ To check out and install the latest source code
 
     git clone https://github.com/google/importlab.git
     cd importlab
-    python setup.py install
+    python -m pip install .
 
 Usage
 -----

--- a/importlab/__main__.py
+++ b/importlab/__main__.py
@@ -23,10 +23,10 @@ import os
 import sys
 from importlib.metadata import version
 
-from importlab import environment
-from importlab import graph
-from importlab import output
-from importlab import utils
+from . import environment
+from . import graph
+from . import output
+from . import utils
 
 
 def parse_args():

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ URL = 'https://github.com/google/importlab'
 EMAIL = 'pytype-dev@google.com'
 AUTHOR = 'Google Inc.'
 REQUIRES_PYTHON = '>=3.6.0'
-VERSION = '0.8'
+VERSION = '0.8.1'
 
 REQUIRED = [
     'networkx>=2',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,9 @@ setup(
     python_requires=REQUIRES_PYTHON,
     url=URL,
     packages=PACKAGES,
-    scripts=['bin/importlab'],
+    entry_points={
+        'console_scripts': ['importlab=importlab.__main__:main'],
+    },
     install_requires=REQUIRED,
     include_package_data=True,
     license='Apache 2.0',


### PR DESCRIPTION
In particular:

* Change script into entry point (https://setuptools.pypa.io/en/latest/userguide/entry_point.html#console-scripts) (like pytype: https://github.com/google/pytype/blob/main/setup.cfg).
* Avoid deprecated setup.py commands (https://setuptools.pypa.io/en/latest/deprecated/commands.html#running-setuptools-commands)

Note that you can also run the tool via `python -m importlab` too now.

Fixes #51